### PR TITLE
Fix for Debian

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,7 @@
 - name: query docker-compose binary path
   shell: which docker-compose
   register: docker_compose_path
+  ignore_errors: True
 
 - name: install docker-compose if not present
   when: docker_compose_path.rc == 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,7 @@
 
 - name: install linux-image-extra matching kernel release
   apt: name=linux-image-extra-{{ kernel_release.stdout }} state=present
+  when: debian_distro.stdout == "ubuntu"
 
 - name: install docker-engine
   apt: name=docker-engine state=present update_cache=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
   when: debian_distro.stdout == "ubuntu"
 
 - name: register apt sources (debian)
-  shell: echo "deb deb https://apt.dockerproject.org/repo debian-{{ debian_release.stdout }} main" > /etc/apt/sources.list.d/docker.list
+  shell: echo "deb https://apt.dockerproject.org/repo debian-{{ debian_release.stdout }} main" > /etc/apt/sources.list.d/docker.list
   when: debian_distro.stdout == "debian"
 
 - name: purge lxc-docker


### PR DESCRIPTION
This fixes a typo in the apt-source file generation for debian.

(Note: Currently still not working for my fresh jessie installation due to not finding the linux-image-extra dependency. Working on that...)
